### PR TITLE
Do use "java.lang.Class" logger

### DIFF
--- a/src/main/java/net/anotheria/db/service/BasePersistenceServiceJDBCImpl.java
+++ b/src/main/java/net/anotheria/db/service/BasePersistenceServiceJDBCImpl.java
@@ -36,7 +36,7 @@ public abstract class BasePersistenceServiceJDBCImpl {
 	/**
 	 * Logger.
 	 */
-	protected Logger log = LoggerFactory.getLogger(BasePersistenceServiceJDBCImpl.class.getClass());
+	protected Logger log = LoggerFactory.getLogger(BasePersistenceServiceJDBCImpl.class);
 
 	/**
 	 * PROXY factory.


### PR DESCRIPTION
Currently _BasePersistenceServiceJDBCImpl_ uses the wrong logger:

`INFO  java.lang.Class - Using config: Driver: org.h2.Driver, Vendor: null, DB: null, Username: myuser, Pwd:mypassword @ localhost:5432, perconfigured: jdbc:h2:mem:test
`
