### PR TITLE
Do not log password in clear text

### DIFF
--- a/src/main/java/net/anotheria/db/config/JDBCConfig.java
+++ b/src/main/java/net/anotheria/db/config/JDBCConfig.java
@@ -70,7 +70,7 @@ public class JDBCConfig{
 	}
 
 	@Override public String toString(){
-        return "Driver: "+ driver +", Vendor: "+ vendor +", DB: "+ db +", Username: "+ username +", Pwd:"+ password +" @ "+ host + ':' + port +", perconfigured: "+ preconfiguredJdbcUrl;
+        return "Driver: "+ driver +", Vendor: "+ vendor +", DB: "+ db +", Username: "+ username +", Pwd: **** @ "+ host + ':' + port +", perconfigured: "+ preconfiguredJdbcUrl;
 	}
 
 	public String getDriver() {


### PR DESCRIPTION
Currently _BasePersistenceServiceJDBCImpl_ logs the database password in clear text:

`INFO  java.lang.Class - Using config: Driver: org.h2.Driver, Vendor: null, DB: null, Username: myuser, Pwd:mypassword @ localhost:5432, perconfigured: jdbc:h2:mem:test
`

This is a security risk.
